### PR TITLE
docs: fix forwardRef warning for typesafe input recipe

### DIFF
--- a/apps/docs-v2/app/routes/_docs.recipes.typesafe-input.mdx
+++ b/apps/docs-v2/app/routes/_docs.recipes.typesafe-input.mdx
@@ -61,11 +61,11 @@ const MyInputImpl = forwardRef<HTMLInputElement, MyInputProps<string>>(
           {...field.getInputProps({
             type,
             id: inputId,
+            ref,
             "aria-describedby": errorId,
             "aria-invalid": !!field.error(),
             ...rest,
           })}
-          ref={ref}
         />
         {field.error() && <p id={errorId}>{field.error()}</p>}
       </div>

--- a/apps/docs-v2/app/routes/_docs.recipes.typesafe-input.mdx
+++ b/apps/docs-v2/app/routes/_docs.recipes.typesafe-input.mdx
@@ -49,7 +49,7 @@ type InputType = <Type extends string>(
 ) => React.ReactNode;
 
 const MyInputImpl = forwardRef<HTMLInputElement, MyInputProps<string>>(
-  ({ label, scope, type, ...rest }) => {
+  ({ label, scope, type, ...rest }, ref) => {
     const field = useField(scope);
     const inputId = useId();
     const errorId = useId();
@@ -65,6 +65,7 @@ const MyInputImpl = forwardRef<HTMLInputElement, MyInputProps<string>>(
             "aria-invalid": !!field.error(),
             ...rest,
           })}
+          ref={ref}
         />
         {field.error() && <p id={errorId}>{field.error()}</p>}
       </div>


### PR DESCRIPTION
This fix solves below browser warning generated when using the current [typesafe input repice ](https://www.rvf-js.io/recipes/typesafe-input#recipe):

```
Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?
```

