### PR TITLE
fix: option values are always strings

### DIFF
--- a/packages/core/src/dom/dom.ts
+++ b/packages/core/src/dom/dom.ts
@@ -31,7 +31,7 @@ export const setFormControlValue = (element: HTMLElement, value: unknown) => {
     for (const option of element.options) {
       option.selected = Array.isArray(value)
         ? value.includes(option.value)
-        : value === option.value;
+        : String(value) === option.value;
     }
   }
 


### PR DESCRIPTION
Hey there, thanks so much for the work you do maintaining this library. We've just migrated from v5 to v6 following your guide, and it was pretty smooth overall. We did find what seems to be a small regression.

In certain cases we're passing numeric default values that control the initial state of a `select` within a `ValidatedForm`, for example:

```tsx
const GigabyteSelector = () => {
  const field = useField("gigabytes")

  return (
    <select id="gigabytes" name="gigabytes" {...field.getInputProps()}>
      {[25, 50, 100, 150].map((gb) => (
        <option key={gb} value={gb}>
          {gb} GB
        </option>
      ))}
    </select>
  )
}

<ValidatedForm defaultValues={{ gigabytes: 100 }}>
  <GigabyteSelector />
</ValidatedForm>
```

It seems that the form scope will hang onto the value as it was passed (an integer in this case), whereas the option will implicitly convert it to a string. Comparing these two values as-is will always return false, and so all options were effectively marked as unselected, always rendering the first option the user.

Let me know your thoughts, or if there's perhaps a better place to make this change. Thanks!