### PR TITLE
Fix peer dependency warning

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "^17.0.2 || ^18.0.0",
-    "@rvf/set-get": ">= 0.0.0 < 1.0.0"
+    "@rvf/set-get": ">= 0.0.0 < 7.0.0"
   },
   "devDependencies": {
     "react-tracked": "^2.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,7 @@
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0",
     "@rvf/core": ">= 0.0.0 < 7.0.0",
-    "@rvf/set-get": ">= 0.0.0 < 1.0.0"
+    "@rvf/set-get": ">= 0.0.0 < 7.0.0"
   },
   "devDependencies": {
     "tsconfig": "*",

--- a/packages/zod-form-data/package.json
+++ b/packages/zod-form-data/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "zod": ">= 3.11.0",
-    "@rvf/set-get": ">= 0.0.0 < 1.0.0"
+    "@rvf/set-get": ">= 0.0.0 < 7.0.0"
   },
   "devDependencies": {
     "@rvf/set-get": "*",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@rvf/core": ">= 0.0.0 < 7.0.0",
-    "@rvf/set-get": ">= 0.0.0 < 1.0.0",
+    "@rvf/set-get": ">= 0.0.0 < 7.0.0",
     "zod": ">= 3.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
If you want to reference `ValidStringPaths` in your code then you get peer dependency warnings once `@rvf/set-get` is installed