### PR TITLE
Improve npm links

### DIFF
--- a/packages/zod-form-data/package.json
+++ b/packages/zod-form-data/package.json
@@ -1,6 +1,7 @@
 {
   "name": "zod-form-data",
   "version": "2.0.2",
+  "homepage": "https://github.com/airjp73/rvf/tree/main/packages/zod-form-data",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -14,7 +15,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/airjp73/remix-validated-form"
+    "url": "https://github.com/airjp73/rvf",
+    "directory": "packages/zod-form-data"
   },
   "scripts": {
     "dev": "tsup --watch",


### PR DESCRIPTION
Hi, thanks for this package! Looks great.

Currently, the links on [the `zod-form-data` npm package page](https://www.npmjs.com/package/zod-form-data) are as follows:

```
Repository
https://github.com/airjp73/remix-validated-form

Homepage
https://github.com/airjp73/remix-validated-form#readme
```

With this PR, they change as follows:

```
Repository
https://github.com/airjp73/rvf

Homepage
https://github.com/airjp73/rvf/tree/main/packages/zod-form-data
```