### PR TITLE
Update `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,4 +8,6 @@
 .gitignore
 .npmignore
 .npmrc
+.turbo
+stats.html
 tsconfig.json


### PR DESCRIPTION
I've noticed in the recent `zod-form-data` release that it includes changes to a huge `stats.html` (maybe from [`rollup-plugin-visualizer`](https://github.com/btd/rollup-plugin-visualizer), though I didn't find any references in this repo).

That file is 219 kB of the 265 kB package size.

The package also include build logs in `.turbo`, which are not necessary to publish (and contain local paths from your development machine).