### PR TITLE
Fix `zfd.formData` input type

### DIFF
--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -125,11 +125,11 @@ type FormDataType = {
   ): ZodEffects<
     ZodObject<T>,
     z.output<ZodObject<T>>,
-    FormData | FormDataLikeInput
+    FormData | FormDataLikeInput | z.input<ZodObject<T>>
   >;
   <T extends z.ZodTypeAny>(
     schema: T,
-  ): ZodEffects<T, z.output<T>, FormData | FormDataLikeInput>;
+  ): ZodEffects<T, z.output<T>, FormData | FormDataLikeInput | z.input<T>>;
 };
 
 const safeParseJson = (jsonString: string) => {


### PR DESCRIPTION
Previously, the `zfd.formData()` input type always inferred as `FormData | FormDataLikeInput`, while we can technically pass in a plain object as input.  So instead, we should also infer the input type from the Zod schema.

Related issue: https://github.com/TheEdoRan/next-safe-action/issues/322