### PR TITLE
unstable_setCustomError and a couple other small improvements

### DIFF
--- a/apps/docs/app/routes/_docs.reference.form-api.mdx
+++ b/apps/docs/app/routes/_docs.reference.form-api.mdx
@@ -266,12 +266,20 @@ This also resets any touched, dirty, or validation errors for the field.
 This works for both controlled and uncontrolled fields.
 For uncontrolled fields, this will manually set the value of the form control using the `ref` returned by `field`.
 
-Optionally, you can pass a default value to reset to.
-This will reset cause `form.defaultValue('myField')` to return the new default value,
-and for `form.dirty('myField')` to return use this new default for comparison.
-Calling `resetForm` or calling `resetField` on a parent field, will undo any default value changes made by `resetField`.
-
 Can also be called without a field name, to reset the currently in-scope field.
+
+Optionally, `resetField` takes a second argument with a few options.
+
+- `keepError`
+
+  When this is `true`, resetting the field won't clear any validation errors for that field.
+
+- `defaultValue`
+
+  This will set a new default value for the field before resetting it.
+  `form.defaultValue('myField')` will return the new default value,
+  and `form.dirty('myField')` will use this new default for comparison.
+  Calling `resetForm` or calling `resetField` on a parent field, will undo any default value changes made by `resetField`.
 
 <Note>
   <details>
@@ -291,7 +299,7 @@ Can also be called without a field name, to reset the currently in-scope field.
     });
     ```
     
-    If you call `form.resetField("address.street", "234 Another St")`,
+    If you call `form.resetField("address.street", { defaultValue: "234 Another St" })`,
     then `form.defaultValue("address.street")` will now return `"234 Another St"`.
 
     *BUT* calling `form.defaultValue("address")` will return the original street,

--- a/apps/docs/app/routes/_docs.reference.use-form.mdx
+++ b/apps/docs/app/routes/_docs.reference.use-form.mdx
@@ -126,6 +126,16 @@ This is intended for advanced use-cases.
 By using this, you're taking control of the submission lifecycle.
 `onSubmitFailure` will _not_ be called as a result of this.
 
+`cancelSubmit` also takes a couple options.
+
+- `shouldFocusErrors`
+
+  When true, the first invalid form field will be focused just like it would normally when validation errors occur.
+
+- `shouldCallOnInvalidSubmit`
+
+  When true, the `onInvalidSubmit` callback passed to `useForm` or `ValidatedForm` will be called as a result of this cancellation.
+
 #### `performSubmit`
 
 This is intended for advanced use-cases.

--- a/apps/docs/app/routes/_docs.supporting-no-js.mdx
+++ b/apps/docs/app/routes/_docs.supporting-no-js.mdx
@@ -14,11 +14,8 @@ However, the way you go about doing this may vary depending on how important thi
 You should fall back to [native browser validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
 when JS is disabled. This is more work to maintain, but it's a better experience for users.
 
-In order to do this properly, you can pass `noValidate` to your form when JS is available.
-A helpful tool for doing that is [useHydrated from remix-utils](https://github.com/sergiodxa/remix-utils#usehydrated).
-If you aren't using remix, you can copy the recipe [here](/recipes/use-hydrated).
-
-This will allow RVF to take over validation when it can,
+RVF will automatically pass `noValidate` to your form when JS is available,.
+This allows RVF to take over validation when it can,
 but will fall back to native browser validation when it can't.
 
 If the native HTML api can't handle all of your validation requirements, you'll also want to read the next section.

--- a/packages/core/src/getters.ts
+++ b/packages/core/src/getters.ts
@@ -33,7 +33,11 @@ export const getFieldDirty = (state: FormStoreValue, fieldName: string) =>
   state.dirtyFields[fieldName] ?? false;
 
 export const getFieldError = (state: FormStoreValue, fieldName: string) => {
-  return state.validationErrors[fieldName] ?? null;
+  return (
+    state.customValidationErrors[fieldName] ??
+    state.validationErrors[fieldName] ??
+    null
+  );
 };
 
 export const getFieldArrayKeys = (state: FormStoreValue, fieldName: string) =>

--- a/packages/core/src/getters.ts
+++ b/packages/core/src/getters.ts
@@ -51,10 +51,15 @@ export const getAllTouched = (state: FormStoreValue) => state.touchedFields;
 export const getAllDirty = (state: FormStoreValue) => state.dirtyFields;
 
 export const getAllErrors = (state: FormStoreValue) => {
-  if (state.submitStatus !== "idle") return state.validationErrors;
-  const fieldsWithErrors = Object.entries(state.validationErrors).filter(
+  const allErrors = {
+    ...state.validationErrors,
+    ...state.customValidationErrors,
+  };
+  if (state.submitStatus !== "idle") return allErrors;
+  const fieldsWithErrors = Object.entries(allErrors).filter(
     ([fieldName]) =>
       state.touchedFields[fieldName] ||
+      state.customValidationErrors[fieldName] ||
       state.validationBehaviorConfig.initial === "onChange",
   );
   return Object.fromEntries(fieldsWithErrors);

--- a/packages/core/src/store.test.tsx
+++ b/packages/core/src/store.test.tsx
@@ -1971,6 +1971,30 @@ it("should override resetField overrides with reset or parent resetFields", () =
   expect(getFieldDefaultValue(store.getState(), "foo")).toEqual({ bar: "bar" });
 });
 
+it("should keep errors if keepError is provided", () => {
+  const store = testStore({
+    defaultValues: {
+      foo: { bar: "bar" },
+    },
+  });
+  store.setState({
+    validationErrors: {
+      foo: "error",
+    },
+    customValidationErrors: {
+      foo: "bar",
+    },
+  });
+
+  store.getState().resetField("foo", {
+    keepError: true,
+  });
+  expect(store.getState()).toMatchObject({
+    validationErrors: { foo: "error" },
+    customValidationErrors: { foo: "bar" },
+  });
+});
+
 it("should be able to override the default value with an explicit null or undefined", () => {
   const store = testStore({
     defaultValues: { foo: { bar: "bar" } },

--- a/packages/core/src/store.test.tsx
+++ b/packages/core/src/store.test.tsx
@@ -7,7 +7,12 @@ import {
 } from "./store";
 import { ValidationBehavior } from "./types";
 import { createValidator } from "./createValidator";
-import { getFieldDefaultValue, getFieldError, getFieldValue } from "./getters";
+import {
+  getAllErrors,
+  getFieldDefaultValue,
+  getFieldError,
+  getFieldValue,
+} from "./getters";
 
 const testStore = (init?: Partial<FormStoreInit>) =>
   createFormStateStore({
@@ -2031,6 +2036,11 @@ describe("custom errors", () => {
       defaultValues: {
         firstName: "Jane",
       },
+      validationBehaviorConfig: {
+        whenSubmitted: "onChange",
+        initial: "onChange",
+        whenTouched: "onChange",
+      },
       mutableImplStore: {
         onSubmitFailure: vi.fn(),
         onSubmitSuccess: vi.fn(),
@@ -2055,14 +2065,19 @@ describe("custom errors", () => {
 
     await store.getState().validate();
     expect(getFieldError(store.getState(), "firstName")).toEqual("Invalid");
+    expect(getAllErrors(store.getState())).toEqual({ firstName: "Invalid" });
 
     store.getState().setCustomError("firstName", "Custom error");
     expect(getFieldError(store.getState(), "firstName")).toEqual(
       "Custom error",
     );
+    expect(getAllErrors(store.getState())).toEqual({
+      firstName: "Custom error",
+    });
 
     store.getState().setCustomError("firstName", null);
     expect(getFieldError(store.getState(), "firstName")).toEqual("Invalid");
+    expect(getAllErrors(store.getState())).toEqual({ firstName: "Invalid" });
   });
 
   it("should fail submission when custom errors are the only errors", async () => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -160,7 +160,18 @@ export type StoreFlags = {
 };
 
 export type CancelSubmitOptions = {
+  /**
+   * When true, the first invalid form field will be focused just like it would normally when validation errors occur.
+   *
+   * @default false
+   */
   shouldFocusErrors?: boolean;
+
+  /**
+   * When true, the `onInvalidSubmit` callback passed to `useForm` or `ValidatedForm` will be called as a result of this cancellation.
+   *
+   * @default false
+   */
   shouldCallOnInvalidSubmit?: boolean;
 };
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -680,11 +680,16 @@ export const createFormStateStore = ({
       focusFirstInvalidField: () => {
         const {
           validationErrors,
+          customValidationErrors,
           flags: { disableFocusOnError },
         } = get();
         if (disableFocusOnError) return;
 
-        const refElementsWithErrors = Object.keys(validationErrors)
+        const allErrors = {
+          ...validationErrors,
+          ...customValidationErrors,
+        };
+        const refElementsWithErrors = Object.keys(allErrors)
           .flatMap((fieldName) => [
             ...transientFieldRefs.getRefs(fieldName),
             ...controlledFieldRefs.getRefs(fieldName),
@@ -692,7 +697,7 @@ export const createFormStateStore = ({
           .filter((val): val is NonNullable<typeof val> => val != null);
 
         if (formRef.current) {
-          const unRegisteredNames = Object.keys(validationErrors).filter(
+          const unRegisteredNames = Object.keys(allErrors).filter(
             (name) =>
               !transientFieldRefs.has(name) && !controlledFieldRefs.has(name),
           );
@@ -841,7 +846,10 @@ export const createFormStateStore = ({
 
         if (!result) result = await doValidation();
 
-        if (result.errors) {
+        if (
+          result.errors ||
+          Object.entries(get().customValidationErrors).length > 0
+        ) {
           get().focusFirstInvalidField();
           await mutableImplStore.onInvalidSubmit?.();
           return;
@@ -977,6 +985,7 @@ export const createFormStateStore = ({
           state.touchedFields = {};
           state.dirtyFields = {};
           state.validationErrors = {};
+          state.customValidationErrors = {};
           state.fieldArrayKeys = {};
           state.arrayUpdateKeys = {};
           state.submitStatus = "idle";
@@ -1007,6 +1016,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,
@@ -1093,6 +1103,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,
@@ -1120,6 +1131,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,
@@ -1130,6 +1142,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,
@@ -1158,6 +1171,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,
@@ -1194,6 +1208,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,
@@ -1225,6 +1240,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,
@@ -1261,6 +1277,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,
@@ -1271,6 +1288,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,
@@ -1308,6 +1326,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,
@@ -1343,6 +1362,7 @@ export const createFormStateStore = ({
             [
               state.touchedFields,
               state.validationErrors,
+              state.customValidationErrors,
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -168,6 +168,7 @@ type StoreState = {
   touchedFields: Record<string, boolean>;
   dirtyFields: Record<string, boolean>;
   validationErrors: Record<string, string>;
+  customValidationErrors: Record<string, string>;
   submitStatus: SubmitStatus;
   fieldArrayKeys: Record<string, Array<string>>;
   arrayUpdateKeys: Record<string, string>;
@@ -208,6 +209,7 @@ type StoreActions = {
   setTouched: (fieldName: string, value: boolean) => void;
   setDirty: (fieldName: string, value: boolean) => void;
   setError: (fieldName: string, value: string | null) => void;
+  setCustomError: (fieldName: string, value: string | null) => void;
 
   setAllValues: (data: FieldValues) => void;
   setAllTouched: (data: Record<string, boolean>) => void;
@@ -454,6 +456,7 @@ export const createFormStateStore = ({
       touchedFields: {},
       dirtyFields: {},
       validationErrors: serverValidationErrors,
+      customValidationErrors: {},
       // If we have default errors, lets treat that as a failed server-side validation
       submitStatus:
         Object.keys(serverValidationErrors).length > 0 ? "error" : "idle",
@@ -937,6 +940,13 @@ export const createFormStateStore = ({
         set((state) => {
           if (value == null) delete state.validationErrors[fieldName];
           else state.validationErrors[fieldName] = value;
+        });
+      },
+
+      setCustomError: (fieldName, value) => {
+        set((state) => {
+          if (value == null) delete state.customValidationErrors[fieldName];
+          else state.customValidationErrors[fieldName] = value;
         });
       },
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -200,7 +200,7 @@ export type SubmitterOptions = {
   formAction?: string;
 };
 
-export type ResetFieldOpts = { defaultValue?: unknown };
+export type ResetFieldOpts = { defaultValue?: unknown; keepError?: boolean };
 
 type StoreEvents = {
   onFieldChange: (
@@ -1042,8 +1042,9 @@ export const createFormStateStore = ({
           deleteFieldsWithPrefix(
             [
               state.touchedFields,
-              state.validationErrors,
-              state.customValidationErrors,
+              ...(opts.keepError
+                ? []
+                : [state.validationErrors, state.customValidationErrors]),
               state.dirtyFields,
               state.fieldArrayKeys,
               state.defaultValueOverrides,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -852,6 +852,10 @@ export const createFormStateStore = ({
         ) {
           get().focusFirstInvalidField();
           await mutableImplStore.onInvalidSubmit?.();
+          if (get().submitStatus === "submitting")
+            set((state) => {
+              state.submitStatus = "error";
+            });
           return;
         }
 

--- a/packages/react/src/array.tsx
+++ b/packages/react/src/array.tsx
@@ -9,7 +9,7 @@ import {
   FieldArrayValidationBehaviorConfig,
 } from "@rvf/core";
 import { makeImplFactory } from "./implFactory";
-import { FormApi, makeBaseFormApi } from "./base";
+import { FormApi, makeBaseFormApi, useHydrated } from "./base";
 import { useFormScopeOrContextInternal } from "./context";
 import { createControlledRef } from "./refs";
 
@@ -119,7 +119,10 @@ export const makeFieldArrayImpl = <FormInputData extends Array<any>>({
   form,
   trackedState,
   validationBehavior,
-}: FieldArrayParams<FormInputData>): FieldArrayApi<FormInputData> => {
+  isHydrated,
+}: FieldArrayParams<FormInputData> & {
+  isHydrated: boolean;
+}): FieldArrayApi<FormInputData> => {
   const arrayFieldName = form.__field_prefix__;
   const itemImpl = makeImplFactory(arrayFieldName, (itemFieldName) =>
     makeBaseFormApi({
@@ -127,6 +130,7 @@ export const makeFieldArrayImpl = <FormInputData extends Array<any>>({
         FormInputData[number]
       >,
       trackedState,
+      isHydrated,
     }),
   );
 
@@ -237,6 +241,7 @@ export function useFieldArray<FormInputData extends any[]>(
   const scope = useFormScopeOrContextInternal(formOrName);
   const { useStoreState } = scope.__store__;
   const trackedState = useStoreState();
+  const isHydrated = useHydrated();
 
   // Accessing _something_ is required. Otherwise, it will rerender on every state update.
   // I saw this done in one of the dia-shi's codebases, too, but I can't find it now.
@@ -248,8 +253,9 @@ export function useFieldArray<FormInputData extends any[]>(
         form: scope as never,
         trackedState,
         validationBehavior,
+        isHydrated,
       }),
-    [scope, trackedState, validationBehavior],
+    [scope, trackedState, validationBehavior, isHydrated],
   );
 
   return base;

--- a/packages/react/src/base.tsx
+++ b/packages/react/src/base.tsx
@@ -84,6 +84,11 @@ export type ResetFieldOpts<FieldValue> = {
    * If you call `resetForm`, this will overwrite any changes made by `resetField`.
    */
   defaultValue?: FieldValue;
+
+  /**
+   * When this is true, resetting the field won't clear any errors on the field.
+   */
+  keepError?: boolean;
 };
 
 type NonUndefined<T> = Exclude<T, undefined>;

--- a/packages/react/src/base.tsx
+++ b/packages/react/src/base.tsx
@@ -261,6 +261,41 @@ export interface FormApi<FormInputData> {
   setTouched(value: boolean): void;
 
   /**
+   * @unstable This API may change
+   *
+   * Sets a custom error message on the specifie field.
+   * By using this, you're taking manual control of the validation lifecycle for this particular error message.
+   *
+   * When a field has a custom error message, it will always be displayed, regardless of the field's touched state.
+   * Custom errors are not cleared until you explicitly clear them.
+   * Clear custom errors by calling this helper again with `null` as the error.
+   *
+   * When a form with a custom error message is submitted, `onBeforeSubmit` will be called, but `onSubmit` will not.
+   * This gives you a chance to re-check your custom validation and maybe clear it.
+   * If you don't clear the error in `onBeforeSubmit` or explicitly call `performSubmit`, then the submit will fail and `onInvalidSubmit` will be called.
+   */
+  unstable_setCustomError(
+    fieldName: ValidStringPaths<FormInputData>,
+    error: string | null,
+  ): void;
+
+  /**
+   * @unstable This API may change
+   *
+   * Sets a custom error message on the field in scope.
+   * By using this, you're taking manual control of the validation lifecycle for this particular error message.
+   *
+   * When a field has a custom error message, it will always be displayed, regardless of the field's touched state.
+   * Custom errors are not cleared until you explicitly clear them.
+   * Clear custom errors by calling this helper again with `null` as the error.
+   *
+   * When a form with a custom error message is submitted, `onBeforeSubmit` will be called, but `onSubmit` will not.
+   * This gives you a chance to re-check your custom validation and maybe clear it.
+   * If you don't clear the error in `onBeforeSubmit` or explicitly call `performSubmit`, then the submit will fail and `onInvalidSubmit` will be called.
+   */
+  unstable_setCustomError(error: string | null): void;
+
+  /**
    * Clears the error of the specified field.
    */
   clearError(fieldName: ValidStringPaths<FormInputData>): void;
@@ -616,6 +651,8 @@ export const makeBaseFormApi = <FormInputData,>({
       transientState().setTouched(...optionalField(args)),
     clearError: (fieldName?: string) =>
       transientState().setError(f(fieldName), null),
+    unstable_setCustomError: (...args: WithOptionalField<string | null>) =>
+      transientState().setCustomError(...optionalField(args)),
 
     focus: (fieldName) => {
       const elements = [

--- a/packages/react/src/base.tsx
+++ b/packages/react/src/base.tsx
@@ -268,7 +268,7 @@ export interface FormApi<FormInputData> {
   /**
    * @unstable This API may change
    *
-   * Sets a custom error message on the specifie field.
+   * Sets a custom error message on the specified field.
    * By using this, you're taking manual control of the validation lifecycle for this particular error message.
    *
    * When a field has a custom error message, it will always be displayed, regardless of the field's touched state.

--- a/packages/react/src/test/custom-errors.test.tsx
+++ b/packages/react/src/test/custom-errors.test.tsx
@@ -29,6 +29,8 @@ it("should handle custom errors", async () => {
       onBeforeSubmit: async (api) => {
         if (api.unvalidatedData.firstName === "Jane")
           form.unstable_setCustomError("firstName", "for real though.");
+        else if (api.unvalidatedData.firstName === "Jane Doe")
+          form.unstable_setCustomError("firstName", "same problem");
         else form.unstable_setCustomError("firstName", null);
       },
       handleSubmit,
@@ -38,6 +40,9 @@ it("should handle custom errors", async () => {
       <form {...form.getFormProps()}>
         <input {...form.getInputProps("firstName")} data-testid="firstName" />
         <pre data-testid="firstName-error">{form.error("firstName")}</pre>
+        <pre data-testid="is-submitting">
+          {form.formState.isSubmitting ? "true" : "false"}
+        </pre>
         <button type="submit" data-testid="submit" />
       </form>
     );
@@ -49,10 +54,12 @@ it("should handle custom errors", async () => {
   expect(screen.getByTestId("firstName-error")).toHaveTextContent("wrong name");
 
   await userEvent.click(screen.getByTestId("submit"));
+  expect(screen.getByTestId("is-submitting")).toHaveTextContent("false");
   expect(screen.getByTestId("firstName-error")).toHaveTextContent(
     "for real though",
   );
   expect(handleSubmit).not.toBeCalled();
+  expect(screen.getByTestId("is-submitting")).toHaveTextContent("false");
 
   // The custom error doesn't go away yet.
   await userEvent.type(screen.getByTestId("firstName"), " Doe");
@@ -61,5 +68,9 @@ it("should handle custom errors", async () => {
   );
 
   await userEvent.click(screen.getByTestId("submit"));
-  expect(handleSubmit).toBeCalled();
+  expect(screen.getByTestId("firstName-error")).toHaveTextContent(
+    "same problem",
+  );
+  expect(handleSubmit).not.toBeCalled();
+  expect(screen.getByTestId("is-submitting")).toHaveTextContent("false");
 });

--- a/packages/react/src/test/custom-errors.test.tsx
+++ b/packages/react/src/test/custom-errors.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useForm } from "../useForm";
+import userEvent from "@testing-library/user-event";
+import { RenderCounter } from "./util/RenderCounter";
+import { FieldErrors, FormScope, createValidator } from "@rvf/core";
+import { useField } from "../field";
+
+it("should handle custom errors", async () => {
+  const handleSubmit = vi.fn();
+  const TextComp = () => {
+    const form = useForm({
+      defaultValues: {
+        firstName: "",
+      },
+      validationBehaviorConfig: {
+        initial: "onChange",
+        whenTouched: "onChange",
+        whenSubmitted: "onChange",
+      },
+      validator: createValidator({
+        validate: (data) => {
+          const errors: FieldErrors = {};
+          if (data.firstName === "Jane") errors["firstName"] = "wrong name";
+          if (Object.keys(errors).length > 0)
+            return Promise.resolve({ error: errors, data: undefined });
+          return Promise.resolve({ data, error: undefined });
+        },
+      }),
+      onBeforeSubmit: async (api) => {
+        if (api.unvalidatedData.firstName === "Jane")
+          form.unstable_setCustomError("firstName", "for real though.");
+        else form.unstable_setCustomError("firstName", null);
+      },
+      handleSubmit,
+    });
+
+    return (
+      <form {...form.getFormProps()}>
+        <input {...form.getInputProps("firstName")} data-testid="firstName" />
+        <pre data-testid="firstName-error">{form.error("firstName")}</pre>
+        <button type="submit" data-testid="submit" />
+      </form>
+    );
+  };
+
+  render(<TextComp />);
+
+  await userEvent.type(screen.getByTestId("firstName"), "Jane");
+  expect(screen.getByTestId("firstName-error")).toHaveTextContent("wrong name");
+
+  await userEvent.click(screen.getByTestId("submit"));
+  expect(screen.getByTestId("firstName-error")).toHaveTextContent(
+    "for real though",
+  );
+  expect(handleSubmit).not.toBeCalled();
+
+  // The custom error doesn't go away yet.
+  await userEvent.type(screen.getByTestId("firstName"), " Doe");
+  expect(screen.getByTestId("firstName-error")).toHaveTextContent(
+    "for real though",
+  );
+
+  await userEvent.click(screen.getByTestId("submit"));
+  expect(handleSubmit).toBeCalled();
+});

--- a/packages/react/src/test/use-native-validity.test.tsx
+++ b/packages/react/src/test/use-native-validity.test.tsx
@@ -117,6 +117,12 @@ describe("useNativeValidityForForm", () => {
         <form {...form.getFormProps()}>
           <input name="foo" data-testid="foo" />
           <input name="bar" data-testid="bar" />
+          <button
+            data-testid="custom-error"
+            onClick={() => {
+              form.unstable_setCustomError("foo", "Custom!");
+            }}
+          />
           <button data-testid="submit" />
         </form>
       );
@@ -133,6 +139,10 @@ describe("useNativeValidityForForm", () => {
 
     await userEvent.type(screen.getByTestId("bar"), "test");
     expect(screen.getByTestId("foo")).toBeValid();
+    expect(screen.getByTestId("bar")).toBeValid();
+
+    await userEvent.click(screen.getByTestId("custom-error"));
+    expect(screen.getByTestId("foo")).toBeInvalid();
     expect(screen.getByTestId("bar")).toBeValid();
   });
 

--- a/packages/react/src/useNativeValidity.tsx
+++ b/packages/react/src/useNativeValidity.tsx
@@ -1,5 +1,6 @@
 import {
   FormScope,
+  getAllErrors,
   getElementsWithNames,
   isFormControl,
   sortByPosition,
@@ -38,8 +39,8 @@ export const useNativeValidityForForm = (scope: FormScope<any>) => {
       abortController = new AbortController();
       const signal = abortController.signal;
 
-      const currentErrors = state.validationErrors;
-      const prevErrors = prevState.validationErrors;
+      const currentErrors = getAllErrors(state);
+      const prevErrors = getAllErrors(prevState);
 
       const getElements = (field: string) => {
         const allRefs = [


### PR DESCRIPTION
I've made a couple breaking-ish tweaks over the last month that I'm finally going to push out.

This also includes an experimental `setCustomError` api on the client side.