### PR TITLE
Fix docs grammar error

### DIFF
--- a/apps/docs/app/routes/_docs.input-types.mdx
+++ b/apps/docs/app/routes/_docs.input-types.mdx
@@ -163,7 +163,7 @@ If you don't set a default value, then it will return a `boolean`.
     - If there is no value prop, then the checkbox will be in the FormData as `"on"`.
     - An unchecked checkbox will not be in the FormData at all.
 
-    Even if you used a `boolean` as the default value, you're schema should expect to
+    Even if you used a `boolean` as the default value, your schema should expect to
     receive `"on" | undefined`.
 
   </Col>


### PR DESCRIPTION
Fixed a typo in the documentation, correcting "you're schema" to "your schema" in the explanation of expected checkbox values.