### PR TITLE
Fixed #457 [Bug]: `zfd.checkbox()` is not passing when type boolean is passed to it

### DIFF
--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -80,6 +80,7 @@ export const checkbox = ({ trueValue = "on" }: CheckboxOpts = {}) =>
   z.union([
     z.literal(trueValue).transform(() => true),
     z.literal(undefined).transform(() => false),
+    z.boolean(),
   ]);
 
 export const file: InputType<z.ZodType<File>> = (schema = z.instanceof(File)) =>

--- a/packages/zod-form-data/src/zod-form-data.test.ts
+++ b/packages/zod-form-data/src/zod-form-data.test.ts
@@ -105,6 +105,12 @@ describe("zod helpers", () => {
       expect(s.parse("asdf")).toBe(true);
     });
 
+    it("should support boolean values", () => {
+      const s = zfd.checkbox();
+      expect(s.parse(true)).toBe(true);
+      expect(s.parse(false)).toBe(false);
+    });
+
     it("should fail anything else", () => {
       const s = zfd.checkbox();
       expectError(s, 123);


### PR DESCRIPTION
Adds `boolean` to the list of valid types that `zfd.checkbox()` supports.