### PR TITLE
Added `infer` type helper

### DIFF
--- a/packages/zod-form-data/README.md
+++ b/packages/zod-form-data/README.md
@@ -247,3 +247,25 @@ const schema = zfd.formData({
   repeatableNumberField: zfd.repeatableOfType(zfd.numeric()),
 });
 ```
+
+### infer
+
+A convenience wrapper for the Zod [infer](https://zod.dev/basics?id=inferring-types) type.
+
+#### Usage
+
+```ts
+const dataSchema = zfd.formData({
+  name: zfd.text(),
+  age: zfd.numeric(),
+  likesPizza: zfd.checkbox(),
+});
+
+type DataType = zfd.infer<typeof dataSchema>;
+
+const dataValue: DataType = {
+  age: 2,
+  likesPizza: true,
+  name: "Billy",
+};
+```

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -193,3 +193,20 @@ export const formData: FormDataType = (shapeOrSchema: any): any =>
     processFormData,
     shapeOrSchema instanceof ZodType ? shapeOrSchema : z.object(shapeOrSchema),
   );
+
+/**
+ * Infers a static type from your schema definition.
+ *
+ * ```ts
+ * const schema = zfd.formData({
+ *   name: zfd.text(),
+ * })
+ *
+ * type Type = zfd.infer<typeof nameSchema> // << This
+ *
+ * const value:Type = { name: "zod-form-data" }
+ * ```
+ *
+ * Note: This is just a re-export of the Zod `infer` type for convenience.
+ */
+export type infer<T extends ZodType> = z.infer<T>;

--- a/packages/zod-form-data/src/helpers.ts
+++ b/packages/zod-form-data/src/helpers.ts
@@ -202,7 +202,7 @@ export const formData: FormDataType = (shapeOrSchema: any): any =>
  *   name: zfd.text(),
  * })
  *
- * type Type = zfd.infer<typeof nameSchema> // << This
+ * type Type = zfd.infer<typeof nameSchema>
  *
  * const value:Type = { name: "zod-form-data" }
  * ```

--- a/packages/zod-form-data/src/zod-form-data.test.ts
+++ b/packages/zod-form-data/src/zod-form-data.test.ts
@@ -409,4 +409,26 @@ describe("zod helpers", () => {
       });
     });
   });
+
+  describe("infer", () => {
+    it("should collect the types information correctly", () => {
+      const dataSchema = zfd.formData({
+        name: zfd.text(),
+        age: zfd.numeric(z.number().min(25).max(50)),
+        likesPizza: zfd.checkbox(),
+      });
+
+      type DataType = zfd.infer<typeof dataSchema>;
+
+      const dataValue: DataType = {
+        age: 2,
+        likesPizza: true,
+        name: "Billy",
+      };
+
+      // Just to get the test runner to say it passes
+      // This test is more about TS type logic than about run time logic
+      expect(dataValue).toBe(dataValue);
+    });
+  });
 });


### PR DESCRIPTION
When doing basic form validation, pretty much everything can be done using just `zfd`, however if you want a portable version of the type from that schema you have to reach for zod.

That is a pain so I'm adding this export of the zod infer type as a convenience for developers.